### PR TITLE
Output proper RSS pubDate episode values.

### DIFF
--- a/generate-snarchive.py
+++ b/generate-snarchive.py
@@ -96,17 +96,18 @@ def get_item(soup, item):
               description=description)
 
 
-def parse_episode_date(dateStr):
+def parse_episode_date(date):
     # Some episodes use 'June', 'July', or 'Sept' for the month, which date parsers don't like.
-    dateParts = dateStr.split(' ')
-    dateParts[1] = dateParts[1][:3]
-    dateStr = ' '.join(dateParts)
+    dateparts = date.split(' ')
+    dateparts[1] = dateparts[1][:3]
+    date = ' '.join(dateparts)
 
     # Convert the date string into a proper RSS pubdate
-    dt = datetime.datetime.strptime(dateStr, "%d %b %Y")
+    pubdate = datetime.datetime.strptime(date, "%d %b %Y").date()
     # The time doesn't really matter, so pretend it was published at 11 PM UTC (3/4 PM PT).
-    pubdate = dt.combine(dt.date(), datetime.time(hour=23), tzinfo=datetime.UTC)
-    return pubdate.strftime("%a, %d %b %Y %H:%M:%S %z")
+    pubtime = datetime.time(hour=23)
+    pubdatetime = datetime.datetime.combine(pubdate, pubtime, tzinfo=datetime.UTC)
+    return pubdatetime.strftime("%a, %d %b %Y %H:%M:%S %z")
 
 
 def item_rss(links):


### PR DESCRIPTION
Previously, this was outputting non-compliant pubDate fields for each episode, which was causing the Apple Podcasts app to indicate all episodes as having an unknown date.

This fixes it by converting the date from a string like "07 Oct 2025" to a python datetime object and then to a proper pubDate string like "Tue, 07 Oct 2025 23:00:00 +0000".

The specific time doesn't particularly matter, but 23:00 UTC was chosen for all episodes since it's still on the same calendar date and is around when most episodes would have been recorded. 23:00 UTC is 3 PM PST or 4 PM PDT, depending daylight savings.